### PR TITLE
Integrate COPASI.js into the test site

### DIFF
--- a/my-dropdown-app/.gitignore
+++ b/my-dropdown-app/.gitignore
@@ -1,0 +1,1 @@
+node_modules 

--- a/my-dropdown-app/package.json
+++ b/my-dropdown-app/package.json
@@ -23,6 +23,7 @@
       "react-app/jest"
     ]
   },
+  "eslintIgnore": ["src/copasijs.js"],
   "browserslist": {
     "production": [
       ">0.2%",

--- a/my-dropdown-app/src/App.js
+++ b/my-dropdown-app/src/App.js
@@ -1,15 +1,40 @@
-import React from 'react';
+import React, {Component} from 'react';
 import DropdownWithPopup from './DropdownWithPopup';
 
-function App() {
-  const initialOptions = { '[A]': true, '[B]': true, '[C]': true };
-  const additionalElements = ['J_0', 'J_1', 'J_2'];
+import {createCpsModule} from './copasijs'
+import {COPASI} from './copasi'
 
-  return (
+export class App extends Component  {
+  
+  componentDidMount() {
+    this.loadCopasiAPI();
+  };
+
+  loadCopasiAPI = async () => {
+    try {
+      await createCpsModule().then(
+        module => {
+          const copasi = new COPASI(module);
+          console.log('using COPASI', copasi.version);
+          this.setState({copasi});
+        }
+      );
+
+    } catch (err) {
+      console.error(`Unexpected error in loadCopasiAPI. [Message: ${err.message}]`);
+    }
+  };
+
+  render() {
+    const initialOptions = { '[A]': true, '[B]': true, '[C]': true };
+    const additionalElements = ['J_0', 'J_1', 'J_2'];
+    
+    return (
       <div className="App">
         <DropdownWithPopup initialOptions={initialOptions} additionalElements={additionalElements} />
+        <div>{this.state?.copasi.version}</div>
       </div>
-  );
+  )};
 }
 
 export default App;

--- a/my-dropdown-app/src/copasi.d.ts
+++ b/my-dropdown-app/src/copasi.d.ts
@@ -1,0 +1,94 @@
+import type exp from "constants";
+
+export interface SimResult {
+    num_variables: number;
+    recorded_steps: number;
+    titles: string[];
+    columns: string[];
+}
+
+export interface SpeciesInfo {
+    compartment: string;
+    concentration: number;
+    id: string;
+    name: string;
+    initial_concentration: number;
+    initial_particle_number: number;
+    particle_number: number;
+    type: string;
+}
+
+export interface CompartmentInfo {
+    id: string;
+    name: string;
+    size: number;
+    type: string;
+}
+export interface LocalParamterInfo {
+    name: string;
+    value: number;
+}
+
+export interface ReactionInfo {
+    id: string;
+    name: string;
+    reversible: boolean;
+    scheme: string;
+    local_paramters: LocalParamterInfo[];
+}
+
+export interface ModelName
+{
+    name: string;
+    notes: string;
+}
+
+export interface GlobalParamterInfo {   
+    name: string;
+    value: number;
+    initial_value: number;
+    id: string;
+    type: string;
+}
+
+export interface ModelInfo {
+    species: SpeciesInfo[];
+    compartments: CompartmentInfo[];
+    reactions: ReactionInfo[];
+    global_parameters: GlobalParamterInfo[];
+    model : ModelName;
+    time: number;
+    status: string;
+    messages: string;
+}
+
+export default class COPASI {
+    constructor(module: any);
+    reset(): void;
+    readonly version: string;
+    _vectorToArray(v: any): any[];
+    loadExample(path: string) : ModelInfo;
+    loadModel(modelCode: string): ModelInfo;
+    simulate() : object;
+    simulate2D() : number[][];
+    simulateEx(startTime : number, endTime : number, numPoints : number) : SimResult;
+    simulateEx2D(startTime : number, endTime : number, numPoints : number) : number[][];
+    simulateYaml(yamlProcessingOptions : string|object) : SimResult;
+    simulateYaml2D(yamlProcessingOptions : string|object) : SimResult;
+    readonly floatingSpeciesConcentrations : number[];
+    readonly ratesOfChange : number[];
+    readonly floatingSpeciesNames : string[];
+    readonly boundarySpeciesConcentrations : number[];
+    readonly boundarySpeciesNames : string[];
+    readonly reactionNames : string[];
+    readonly reactionRates : number[];
+    readonly compartmentNames : string[];
+    readonly compartmentSizes : number[];
+    readonly globalParameterNames : string[];
+    readonly globalParameterValues : number[];
+    readonly localParameterNames : string[];
+    readonly localParameterValues : number[];
+}
+
+export {COPASI};
+export default COPASI;

--- a/my-dropdown-app/src/copasi.js
+++ b/my-dropdown-app/src/copasi.js
@@ -1,0 +1,338 @@
+/**
+ * @class COPASI
+ * 
+ * This class wraps all the functions exported from
+ * emscripten and provides a more convenient interface.
+ */
+class COPASI {
+
+    /**
+     * @enum {string} TC
+     * 
+     * enum for method names
+     * 
+     * @property {string} LSODA Deterministic (LSODA)
+     * @property {string} RADAU5 Deterministic (RADAU5)
+     * @property {string} DIRECT_METHOD Stochastic (Direct method)
+     * @property {string} GIBSON_BRUCK Stochastic (Gibson + Bruck)
+     * @property {string} TAULEAP Stochastic (τ-Leap)
+     */
+    TC = {
+        LSODA: 'Deterministic (LSODA)',
+        RADAU5: 'Deterministic (RADAU5)',
+        DIRECT_METHOD: 'Stochastic (Direct method)',
+        GIBSON_BRUCK: 'Stochastic (Gibson + Bruck)',
+        TAULEAP: 'Stochastic (τ-Leap)',
+    };
+
+    /**
+     * Constructs a new COPASI instance from the WASM module
+     * @param Module the WASM module
+     * 
+     */
+    constructor(Module) {
+        this.Module = Module;
+
+        // initialize wasm methods
+        this.getVersion = Module.getVersion
+        this.getMessages = Module.getMessages;
+        this.steadyState = Module.steadyState;
+        this.oneStep = Module.oneStep;
+        this.initCps = Module.initCps;
+        this.destroy = Module.destroy;
+
+        // init runtime
+        this.initCps();
+    }
+
+    /**
+     * loads an example (if the WASM module was compiled with FS support)
+     * 
+     * @param {string} path 
+     * @returns model information as an object
+     */
+    loadExample(path) 
+    {
+        return JSON.parse(this.Module.loadFromFile(path));
+    }
+
+    /**
+     * Loads a model from a string containing the model in 
+     * SBML or COPASI format. 
+     * 
+     * @param {string} modelCode in SBML or COPASI format
+     * @returns model information as an object
+     */
+    loadModel(modelCode)
+    {
+        return JSON.parse(this.Module.loadModel(modelCode));
+    }
+
+    /**
+     * simulates the currently loaded model with its current 
+     * time course settings.
+     * 
+     * @returns {object} simulation results as object
+     */
+    simulate() {
+        return JSON.parse(this.Module.simulate());
+    }
+
+    /**
+     * simulates the currently loaded model with its current 
+     * time course settings.
+     * 
+     * @returns {number[][]} simulation results as 2D array
+     */
+    simulate2D() {
+        this.Module.simulate();
+        return this._vector2dToArray(this.Module.getSimulationResults2D());
+    }
+
+    /**
+     * simulates the currently loaded model from startTime to 
+     * endTime with numPoints points.
+     * 
+     * @param {number} startTime
+     * @param {number} endTime
+     * @param {number} numPoints
+     * 
+     * @returns {object} simulation results as object
+     */
+    simulateEx(startTime, endTime, numPoints) {
+        return this.Module.simulateEx(startTime, endTime, numPoints);
+    }
+
+    /**
+     * simulates the currently loaded model from startTime to 
+     * endTime with numPoints points.
+     * 
+     * @param {number} startTime
+     * @param {number} endTime
+     * @param {number} numPoints
+     * 
+     * @returns {number[][]} simulation results as 2D array
+     */
+    simulateEx2D(startTime, endTime, numPoints) {
+        this.Module.simulateEx(startTime, endTime, numPoints);
+        return this._vector2dToArray(this.Module.getSimulationResults2D());
+    }
+
+    /**
+     * simulates the currently loaded model after applying
+     * the processing instructions: 
+     * 
+     * @param {object|string} yamlProcessingOptions
+     * @returns {object} simulation results as object
+     */
+    simulateYaml(yamlProcessingOptions) {
+        if (typeof yamlProcessingOptions !== 'string') {
+            yamlProcessingOptions = JSON.stringify(yamlProcessingOptions);
+        }
+        return JSON.parse(this.Module.simulateYaml(yamlProcessingOptions));
+    }
+
+    /**
+     * simulates the currently loaded model after applying
+     * the processing instructions: 
+     * 
+     * @param {object|string} yamlProcessingOptions
+     * @returns {number[][]} simulation results as 2D array
+     */
+    simulateYaml2D(yamlProcessingOptions) {
+        if (typeof yamlProcessingOptions !== 'string') {
+            yamlProcessingOptions = JSON.stringify(yamlProcessingOptions);
+        }
+        this.Module.simulateYaml(yamlProcessingOptions);
+        return this._vector2dToArray(this.Module.getSimulationResults2D());
+    }
+
+    /**
+     * resets the model
+     * 
+     * after loading the model, its state was saved as parameterset, 
+     * calling reset will apply that parameter set.
+     */
+    reset() {
+        // Add code here to reset the simulator
+        this.Module.reset();
+    }
+
+
+    /**
+     * @property {string} version returns the COPASI version
+     * 
+     * @example
+     * var copasi = new COPASI(Module);
+     * console.log(copasi.version);
+     * // prints something like:
+     * // 4.32.284
+     */
+    get version() {
+        return this.Module.getVersion();
+    }
+
+    _vectorToArray(v) {
+        var result = [];
+        for (var i = 0; i < v.size(); i++) {
+            result.push(v.get(i));
+        }
+        return result;
+    }
+
+    // convert 2d vector to Array
+    _vector2dToArray(v) {
+        var result = [];
+        for (var i = 0; i < v.size(); i++) {
+            result.push(this._vectorToArray(v.get(i)));
+        }
+        return result;
+    }
+
+    /**
+     * @property {number[]} floatingSpeciesConcentrations returns floating species concentrations
+     */
+    get floatingSpeciesConcentrations() {
+        return this._vectorToArray(this.Module.getFloatingSpeciesConcentrations());
+    }
+
+    /**
+     * @property {number[]} ratesOfChange returns rates of change of floating species
+     */
+    get ratesOfChange() {
+        return this._vectorToArray(this.Module.getRatesOfChange());
+    }
+
+    /**
+     * @property {string[]} floatingSpeciesNames returns floating species names
+     */
+    get floatingSpeciesNames() {
+        return this._vectorToArray(this.Module.getFloatingSpeciesNames());
+    }
+
+    /**
+     * @property {number[]} boundarySpeciesConcentrations returns boundary species concentrations
+     */
+    get boundarySpeciesConcentrations() {
+        return this._vectorToArray(this.Module.getBoundarySpeciesConcentrations());
+    }
+
+    /**
+     * @property {string[]} boundarySpeciesNames returns boundary species names
+     */
+    get boundarySpeciesNames() {
+        return this._vectorToArray(this.Module.getBoundarySpeciesNames());
+    }
+
+    /**
+     * @property {string[]} reactionNames returns reaction names
+     */
+    get reactionNames() {
+        return this._vectorToArray(this.Module.getReactionNames());
+    }
+    
+    /**
+     * @property {number[]} reactionRates returns reaction rates
+     */
+    get reactionRates() {
+        return this._vectorToArray(this.Module.getReactionRates());
+    }
+
+    /**
+     * @property {string[]} compartmentNames returns compartment names
+     */
+    get compartmentNames() {
+        return this._vectorToArray(this.Module.getCompartmentNames());
+    }
+
+    /**
+     * @property {number[]} compartmentSizes returns compartment sizes
+     */
+    get compartmentSizes() {
+        return this._vectorToArray(this.Module.getCompartmentSizes());
+    }
+
+    /**
+     * @property {string[]} globalParameterNames returns global parameter names
+     */
+    get globalParameterNames() {
+        return this._vectorToArray(this.Module.getGlobalParameterNames());
+    }
+
+    /**
+     * @property {number[]} globalParameterValues returns global parameter values
+     */
+    get globalParameterValues() {
+        return this._vectorToArray(this.Module.getGlobalParameterValues());
+    }
+
+    /**
+     * @property {string[]} localParameterNames returns local parameter names
+     * 
+     * Local parameter names, consist of the reaction name in brackets, followed by a dot 
+     * and the parameter name. So for example: `(reaction1).k1` for the 
+     * local parameter `k1` of the reaction `reaction1`.
+     */
+    get localParameterNames() {
+        return this._vectorToArray(this.Module.getLocalParameterNames());
+    }
+
+    /**
+     * @property {number[]} localParameterValues returns local parameter values
+     */
+    get localParameterValues() {
+        return this._vectorToArray(this.Module.getLocalParameterValues());
+    }
+
+    /**
+     * @property {object} timeCourseSettings returns the time course settings as json object
+     * 
+     * @param {object|string} arg the time course settings to set
+     */
+    get timeCourseSettings() {
+        return JSON.parse(this.Module.getTimeCourseSettings());
+    }
+
+    set timeCourseSettings(arg) {
+        // test wether arg is string, otherwise stringify
+        if (typeof arg !== 'string') {
+            arg = JSON.stringify(arg);
+        }
+        return this.Module.setTimeCourseSettings(arg);
+    }
+
+    /**
+     * @property {object} modelInfo model information as object
+     */
+    get modelInfo() {
+        return JSON.parse(this.Module.getModelInfo());
+    }
+
+    /**
+     * @property {string[]} selectionList returns the selection list
+     * 
+     * The selection list controls what will be in the output of the 
+     * simulation calls. 
+     */
+    get selectionList() {
+        return this._vectorToArray(this.Module.getSelectionList());
+    }
+
+    set selectionList(arg) 
+    {
+        var vector = new this.Module.StringVector();
+        arg.forEach((item) => vector.push_back(item));
+        return this.Module.setSelectionList(vector);
+    }
+
+    /**
+     * @property {number[]} selectedValues returns the selected values
+     */
+    get selectedValues() {
+        return this._vectorToArray(this.Module.getSelectedValues());
+    }
+}
+
+// if module is defined, export the COPASI class
+export default COPASI;
+export {COPASI};


### PR DESCRIPTION
The PR shows the step necessary to get the simulator instance instantiated, 

- main difference is that in `App.js` it is no longer a single function serving the site, but a component. 
- added COPASI.js build to `src` (i was not able to get the WASM included, so instead added the single file js version which unfortunately 3MB larger)
- changed `package.json` to ignore the emscripten generated file 
