### PR TITLE
Minor fixes and add reload warning

### DIFF
--- a/my-dropdown-app/src/components/main/DropdownWithPopup.js
+++ b/my-dropdown-app/src/components/main/DropdownWithPopup.js
@@ -153,6 +153,8 @@ A = 10
     const [lineWidthMap, setLineWidthMap] = useState({});
     const [lineStyleMap, setLineStyleMap] = useState({});
 
+    const [lastLoadedModelText, setLastLoadedModelText] = useState("");
+
     const resetContent = () => {
         setSelectedOptions([]);
         set_xAxis_selected_option(null);
@@ -352,7 +354,7 @@ A = 10
         if (editorInstance) {
             editorInstance.setValue(content); // Set the new content in the editor
         }
-
+        setLastLoadedModelText(content);
         // Perform additional actions
         handleResetInApp();
         handleResetParameters();
@@ -806,6 +808,19 @@ A = 10
 
         return () => disposable.dispose();
     }, [editorInstance]);
+
+    useEffect(() => {
+        const handleBeforeUnload = (event) => {
+            event.preventDefault();
+            event.returnValue = '';
+        };
+        if (currentEditorContent !== lastLoadedModelText) {
+            window.addEventListener('beforeunload', handleBeforeUnload);
+        }
+        return () => {
+            window.removeEventListener('beforeunload', handleBeforeUnload);
+        };
+    }, [currentEditorContent, lastLoadedModelText]);
 
     return (
         <div className={`main-container ${isDarkMode ? "dark-mode" : "bright-mode"}`}>

--- a/my-dropdown-app/src/components/main/right-panel/RightPanel.js
+++ b/my-dropdown-app/src/components/main/right-panel/RightPanel.js
@@ -214,24 +214,6 @@ const RightPanel = (props, ref) => {
     };
   }, [isDragging]);
 
-
-  //displays warning message if user tries to reload after simulating
-  useEffect(() => {
-    const handleBeforeUnload = (event) => {
-      event.preventDefault();
-      event.returnValue = "";
-    };
-
-    if (data?.columns && data.columns.length > 0) {
-      window.addEventListener("beforeunload", handleBeforeUnload);
-    }
-
-    return () => {
-      window.removeEventListener("beforeunload", handleBeforeUnload);
-    };
-  }, [data]);
-
-
   // Implement functions for Edit Graph popup draggable
   const handleMouseDown = (e) => {
     setIsDragging(true);

--- a/my-dropdown-app/src/components/main/right-panel/RightPanel.js
+++ b/my-dropdown-app/src/components/main/right-panel/RightPanel.js
@@ -171,6 +171,9 @@ const RightPanel = (props, ref) => {
   const plotHeight = (isSteadyStateDocked) ? graphHeight - 150 : window.innerHeight * 0.55;
   const isResizing = useRef(false);
 
+  //decimal place for data table
+  const [decimalPlaces, setDecimalPlaces] = useState(2);
+
 //	const plotHeight = isDataTableDocked
 //	  ? window.innerHeight * 0.35 // Adjust this value as needed
 //	  : window.innerHeight * 0.55; // Adjust this value as needed
@@ -210,6 +213,24 @@ const RightPanel = (props, ref) => {
       window.removeEventListener("mouseup", handleMouseUp);
     };
   }, [isDragging]);
+
+
+  //displays warning message if user tries to reload after simulating
+  useEffect(() => {
+    const handleBeforeUnload = (event) => {
+      event.preventDefault();
+      event.returnValue = "";
+    };
+
+    if (data?.columns && data.columns.length > 0) {
+      window.addEventListener("beforeunload", handleBeforeUnload);
+    }
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [data]);
+
 
   // Implement functions for Edit Graph popup draggable
   const handleMouseDown = (e) => {
@@ -298,14 +319,10 @@ const RightPanel = (props, ref) => {
 
   const handleShowMoreData = () => {
     if (!data || !data.columns || data.columns.length === 0) {
-      window.alert("Run Simulate to show more data");
+      window.alert("Run simulate to show more data");
     } else {
       setShowMoreDataPopup(true);
     }
-  };
-
-  const handleCloseDataTable = () => {
-    setShowMoreDataPopup(false);
   };
 
   // There are 5 buttons in Edit Graph: Graph, Axes, Grid, Series, Legend
@@ -632,7 +649,8 @@ const RightPanel = (props, ref) => {
                   data={data}
                   isDarkMode={isDarkMode}
                   isDocked={true}
-                  onClose={handleCloseDataTable}
+                  decimalPlaces={decimalPlaces}
+                  setDecimalPlaces={setDecimalPlaces}
                 />
               ) : (
                 <div style={{ 
@@ -641,7 +659,7 @@ const RightPanel = (props, ref) => {
                   textAlign: "center",
                   fontSize: "1.1em"
                 }}>
-                  Run Simulate to show data
+                  Run simulate to show data
                 </div>
               )}
             </div>

--- a/my-dropdown-app/src/components/main/right-panel/data-table-popup/DataTablePopup.js
+++ b/my-dropdown-app/src/components/main/right-panel/data-table-popup/DataTablePopup.js
@@ -3,7 +3,7 @@ import Draggable from "react-draggable";
 import chroma from "chroma-js";
 import "./DataTablePopup.css";
 
-const DataTablePopup = ({ data, onClose, isDarkMode, isDocked, onDock }) => {
+const DataTablePopup = ({ data, isDarkMode, isDocked, onDock, decimalPlaces, setDecimalPlaces }) => {
   const [hoveredData, setHoveredData] = useState({
     title: "",
     index: -1,
@@ -12,8 +12,6 @@ const DataTablePopup = ({ data, onClose, isDarkMode, isDocked, onDock }) => {
   });
   const [size, setSize] = useState({ width: 700, height: 500 });
   const nodeRef = useRef(null);
-
-  const [decimalPlaces, setDecimalPlaces] = useState(2);
 
   const allNumericValues = data.columns
     .flat()
@@ -198,16 +196,6 @@ const DataTablePopup = ({ data, onClose, isDarkMode, isDocked, onDock }) => {
               }}
             >
               Save as CSV
-            </button>
-            <button
-              onClick={onClose}
-              style={{
-                backgroundColor: isDarkMode ? "black" : "white",
-                border: isDarkMode ? "1px solid grey" : "1px solid black",
-                color: isDarkMode ? "white" : "black",
-              }}
-            >
-              Close
             </button>
           </div>
         </div>


### PR DESCRIPTION
changed files: 
RightPanel.js
DataTablePopup.js
DropdownWithPopup.js

Minor fixes:
- When a user changes the decimal place number in the data tab, it will be maintained even if they switch tabs
- got rid of the close button in the data tab

Other change:
After loading a model from the disk, if the user makes changes to the model in the center panel, an alert pops up after they try reloading

steps to test:
- load model
- change some text in the center panel
- try reloading, an alert should pop up
