### PR TITLE
Steady state bug

### DIFF
--- a/my-dropdown-app/src/components/main/left-panel/steady-state/SteadyState.js
+++ b/my-dropdown-app/src/components/main/left-panel/steady-state/SteadyState.js
@@ -201,7 +201,7 @@ class SteadyState extends Component {
                                             style={this.generalStyle(isDarkMode, "black", "white")}
                                             onClick={this.handleShowMoreClick}
                                         >
-                                            More >>
+                                            More {'>>'}
                                         </button>
                                     </div>
                                 </>

--- a/my-dropdown-app/src/components/main/left-panel/steady-state/SteadyStateMorePopup.js
+++ b/my-dropdown-app/src/components/main/left-panel/steady-state/SteadyStateMorePopup.js
@@ -285,19 +285,18 @@ class SteadyStateMorePopup extends Component {
 							Elasticities
 						</button>
 					</div>
-                    {/* Scrollable container for table */}
-                    <div style={{ flex: 1, overflowY: "auto", padding: "20px" }}>
+                    {/* docked table (same as undocked) */}
+                    <div className="steady-state-popup-jacobian-table-container"
+                        style={{
+                            flex: 1,
+                            overflowY: "auto",
+                            ...this.generalStyle("#242323", "white", "", "", "#242323", "white", "0px")
+                        }}>
                         {this.state.showJacobian && this.renderTable(this.props.jacobian)}
+                        {this.state.showFluxControl && this.renderTable(this.props.fluxControl)}
+                        {this.state.showConcentrationControl && this.renderTable(this.props.concentration)}
+                        {this.state.showElasticities && this.renderTable(this.props.elasticities)}
                     </div>
-                    <div style={{ flex: 1, overflowY: "auto", padding: "20px", marginTop: "-50%" }}>
-						{this.state.showFluxControl && this.renderTable(this.props.fluxControl)}
-					</div>
-					<div style={{ flex: 1, overflowY: "auto", padding: "20px", marginTop: "-50%" }}>
-						{this.state.showConcentrationControl && this.renderTable(this.props.concentration)}
-					</div>
-					<div style={{ flex: 1, overflowY: "auto", padding: "20px", marginTop: "-50%" }}>
-						{this.state.showElasticities && this.renderTable(this.props.elasticities)}
-					</div>
 
 
                     {/* Fixed container for buttons */}

--- a/my-dropdown-app/src/components/main/right-panel/RightPanel.js
+++ b/my-dropdown-app/src/components/main/right-panel/RightPanel.js
@@ -181,14 +181,14 @@ const RightPanel = (props, ref) => {
   // Add new state for active tab
   const [activeTab, setActiveTab] = useState('graph');
   
-  // Auto-switch to steady state tab when docked
+  //auto-switch to steady state tab when first docked, and switch back to graph when undocked
   useEffect(() => {
     if (isSteadyStateDocked && activeTab !== 'steadystate') {
       setActiveTab('steadystate');
     } else if (!isSteadyStateDocked && activeTab === 'steadystate') {
       setActiveTab('graph');
     }
-  }, [isSteadyStateDocked, activeTab]);
+  }, [isSteadyStateDocked]);
 
   useEffect(() => {
     if (isNewTabCreated) {
@@ -223,7 +223,6 @@ const RightPanel = (props, ref) => {
     };
   }, [isDragging]);
 
-  // Implement functions for Edit Graph popup draggable
   const handleMouseDown = (e) => {
     setIsDragging(true);
     setDragOffset({

--- a/my-dropdown-app/src/components/main/right-panel/RightPanel.js
+++ b/my-dropdown-app/src/components/main/right-panel/RightPanel.js
@@ -837,6 +837,19 @@ const RightPanel = (props, ref) => {
           </div>
         </div>
       )}
+      
+      {showSteadyStatePopup && (
+        <SteadyStateMorePopup
+          isDarkMode={isDarkMode}
+          jacobian={jacobian}
+          fluxControl={fluxControl}
+          concentration={concentration}
+          elasticities={elasticities}
+          isDocked={isSteadyStateDocked}
+          onClose={handleCloseSteadyStatePopup}
+          onDock={handleSteadyStateDock}
+        />
+      )}
     </div>
   );
 };

--- a/my-dropdown-app/src/components/main/right-panel/RightPanel.js
+++ b/my-dropdown-app/src/components/main/right-panel/RightPanel.js
@@ -180,6 +180,15 @@ const RightPanel = (props, ref) => {
 
   // Add new state for active tab
   const [activeTab, setActiveTab] = useState('graph');
+  
+  // Auto-switch to steady state tab when docked
+  useEffect(() => {
+    if (isSteadyStateDocked && activeTab !== 'steadystate') {
+      setActiveTab('steadystate');
+    } else if (!isSteadyStateDocked && activeTab === 'steadystate') {
+      setActiveTab('graph');
+    }
+  }, [isSteadyStateDocked, activeTab]);
 
   useEffect(() => {
     if (isNewTabCreated) {
@@ -403,6 +412,21 @@ const RightPanel = (props, ref) => {
           >
             Data
           </button>
+          {isSteadyStateDocked && (
+            <button
+              style={{
+                padding: "8px 16px",
+                backgroundColor: activeTab === 'steadystate' ? (isDarkMode ? "#4a4a4a" : "#d6d6d6") : "transparent",
+                border: "none",
+                color: isDarkMode ? "white" : "black",
+                cursor: "pointer",
+                borderBottom: activeTab === 'steadystate' ? `2px solid ${isDarkMode ? "white" : "black"}` : "none"
+              }}
+              onClick={() => setActiveTab('steadystate')}
+            >
+              Steady State
+            </button>
+          )}
         </div>
 
         {/* Content area */}
@@ -646,6 +670,32 @@ const RightPanel = (props, ref) => {
               )}
             </div>
           )}
+          {activeTab === 'steadystate' && (
+            <div style={{ height: "100%" }}>
+              {jacobian && jacobian.rows && jacobian.rows.length > 0 ? (
+                <SteadyStateMorePopup
+                  isDarkMode={isDarkMode}
+                  jacobian={jacobian}
+                  fluxControl={fluxControl}
+                  concentration={concentration}
+                  elasticities={elasticities}
+                  isDocked={true}
+                  onClose={handleCloseSteadyStatePopup}
+                  onDock={handleSteadyStateDock}
+                  onUndock={handleCloseSteadyStatePopup}
+                />
+              ) : (
+                <div style={{ 
+                  padding: "20px", 
+                  color: isDarkMode ? "white" : "black",
+                  textAlign: "center",
+                  fontSize: "1.1em"
+                }}>
+                  Compute steady state to show analysis data
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </div>
       {showEditGraphPopup && (
@@ -848,6 +898,7 @@ const RightPanel = (props, ref) => {
           isDocked={isSteadyStateDocked}
           onClose={handleCloseSteadyStatePopup}
           onDock={handleSteadyStateDock}
+          onUndock={handleCloseSteadyStatePopup}
         />
       )}
     </div>


### PR DESCRIPTION
Overview: fixed issue where clicking the More button in steady state doesn't do anything

Steps to test: Select example model, select steady state, click compute steady state, click more
- a popup should appear and you should be able to dock it and then switch to the other graph or data tabs and also undock it.

Files changed: SteadyState.js and added the popup to RightPanel.js